### PR TITLE
Complete changes required to prevent QTKit inclusion on ARM builds

### DIFF
--- a/macoslib/QTKit.xojo_code
+++ b/macoslib/QTKit.xojo_code
@@ -2,10 +2,14 @@
 Protected Module QTKit
 	#tag Method, Flags = &h1
 		Protected Function Load() As Boolean
-		  dim b as NSBundle = NSBundle.LoadFromPath("/System/Library/Frameworks/QTKit.framework")
-		  if b <> nil then
-		    return b.Load
-		  end if
+		  #if targetMacOS and targetX86
+		    dim b as NSBundle = NSBundle.LoadFromPath("/System/Library/Frameworks/QTKit.framework")
+		    if b <> nil then
+		      return b.Load
+		    end if
+		  #else
+		    return false
+		  #endif
 		End Function
 	#tag EndMethod
 

--- a/macoslib/QTKit/QTCaptureConnection.xojo_code
+++ b/macoslib/QTKit/QTCaptureConnection.xojo_code
@@ -4,14 +4,14 @@ Inherits NSObject
 	#tag ComputedProperty, Flags = &h0
 		#tag Getter
 			Get
-			  #if targetMacOS and targetX86
+			  #If targetMacOS and targetX86
 			    declare function isEnabled lib QTKit.framework selector "isEnabled" (obj_id as Ptr) as Boolean
 			  #endif
 			End Get
 		#tag EndGetter
 		#tag Setter
 			Set
-			  #if targetMacOS and targetX86
+			  #If targetMacOS and targetX86
 			    declare sub setEnabled lib QTKit.framework selector "setEnabled:" (obj_id as Ptr, value as Boolean)
 			    
 			    setEnabled(self, value)
@@ -27,7 +27,7 @@ Inherits NSObject
 	#tag ComputedProperty, Flags = &h0
 		#tag Getter
 			Get
-			  #if targetMacOS and targetX86
+			  #If targetMacOS and targetX86
 			    declare function mediaType lib QTKit.framework selector "mediaType" (obj_id as Ptr) as Ptr
 			    
 			    return RetainedStringValue(mediaType(self))
@@ -41,14 +41,19 @@ Inherits NSObject
 	#tag ViewBehavior
 		#tag ViewProperty
 			Name="Description"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="String"
 			EditorType="MultiLineEditor"
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Enabled"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="Boolean"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Index"
@@ -56,6 +61,7 @@ Inherits NSObject
 			Group="ID"
 			InitialValue="-2147483648"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Left"
@@ -63,10 +69,13 @@ Inherits NSObject
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="MediaType"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="String"
 			EditorType="MultiLineEditor"
 		#tag EndViewProperty
@@ -74,13 +83,17 @@ Inherits NSObject
 			Name="Name"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Super"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Top"
@@ -88,6 +101,7 @@ Inherits NSObject
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 	#tag EndViewBehavior
 End Class

--- a/macoslib/QTKit/QTCaptureDevice.xojo_code
+++ b/macoslib/QTKit/QTCaptureDevice.xojo_code
@@ -3,7 +3,7 @@ Class QTCaptureDevice
 Inherits NSObject
 	#tag Method, Flags = &h0
 		Sub Close()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub close lib QTKit.framework selector "close" (obj_id as Ptr)
 		    
 		    if self.IsOpen then
@@ -21,7 +21,7 @@ Inherits NSObject
 
 	#tag Method, Flags = &h0
 		Function HasMediaType(mediaType as String) As Boolean
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare function hasMediaType lib QTKit.framework selector "hasMediaType:" (obj_id as Ptr, mediaType as CFStringRef) as Boolean
 		    
 		    return hasMediaType(self, mediaType)
@@ -31,7 +31,7 @@ Inherits NSObject
 
 	#tag Method, Flags = &h0
 		Shared Function InputDevices() As QTCaptureDevice()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare function inputDevices lib QTKit.framework selector "inputDevices" (class_id as Ptr) as Ptr
 		    
 		    dim theArray as new CFArray(inputDevices(Cocoa.NSClassFromString("QTCaptureDevice")), not CFArray.hasOwnership)
@@ -47,7 +47,7 @@ Inherits NSObject
 
 	#tag Method, Flags = &h0
 		Sub Open()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare function open lib QTKit.framework selector "open:" (obj_id as Ptr, ByRef errorPtr as Ptr) as Boolean
 		    
 		    dim errorPtr as Ptr
@@ -64,7 +64,7 @@ Inherits NSObject
 	#tag ComputedProperty, Flags = &h0
 		#tag Getter
 			Get
-			  #if targetMacOS and targetX86
+			  #If targetMacOS and targetX86
 			    declare function localizedDisplayName lib QTKit.framework selector "localizedDisplayName" (obj_id as Ptr) as Ptr
 			    
 			    return RetainedStringValue(localizedDisplayName(self))
@@ -77,7 +77,7 @@ Inherits NSObject
 	#tag ComputedProperty, Flags = &h0
 		#tag Getter
 			Get
-			  #if targetMacOS and targetX86
+			  #If targetMacOS and targetX86
 			    declare function isConnected lib QTKit.framework selector "isConnected" (obj_id as Ptr) as Boolean
 			    
 			    return isConnected(self)
@@ -90,7 +90,7 @@ Inherits NSObject
 	#tag ComputedProperty, Flags = &h0
 		#tag Getter
 			Get
-			  #if targetMacOS and targetX86
+			  #If targetMacOS and targetX86
 			    declare function isInUseByAnotherApplication lib QTKit.framework selector "isInUseByAnotherApplication" (obj_id as Ptr) as Boolean
 			    
 			    return isInUseByAnotherApplication(self)
@@ -103,7 +103,7 @@ Inherits NSObject
 	#tag ComputedProperty, Flags = &h0
 		#tag Getter
 			Get
-			  #if targetMacOS and targetX86
+			  #If targetMacOS and targetX86
 			    declare function isOpen lib QTKit.framework selector "isOpen" (obj_id as Ptr) as Boolean
 			    
 			    return isOpen(self)
@@ -116,7 +116,7 @@ Inherits NSObject
 	#tag ComputedProperty, Flags = &h0
 		#tag Getter
 			Get
-			  #if targetMacOS and targetX86
+			  #If targetMacOS and targetX86
 			    declare function uniqueID lib QTKit.framework selector "uniqueID" (obj_id as Ptr) as Ptr
 			    
 			    return RetainedStringValue(uniqueID(self))
@@ -134,13 +134,17 @@ Inherits NSObject
 	#tag ViewBehavior
 		#tag ViewProperty
 			Name="Description"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="String"
 			EditorType="MultiLineEditor"
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="DisplayName"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="String"
 			EditorType="MultiLineEditor"
 		#tag EndViewProperty
@@ -150,21 +154,31 @@ Inherits NSObject
 			Group="ID"
 			InitialValue="-2147483648"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="IsConnected"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="Boolean"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="IsInUseByAnotherApplication"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="Boolean"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="IsOpen"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="Boolean"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Left"
@@ -172,18 +186,23 @@ Inherits NSObject
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Name"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Super"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Top"
@@ -191,10 +210,13 @@ Inherits NSObject
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="UniqueID"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="String"
 			EditorType="MultiLineEditor"
 		#tag EndViewProperty

--- a/macoslib/QTKit/QTCaptureDeviceInput.xojo_code
+++ b/macoslib/QTKit/QTCaptureDeviceInput.xojo_code
@@ -3,7 +3,7 @@ Class QTCaptureDeviceInput
 Inherits NSObject
 	#tag Method, Flags = &h1000
 		Sub Constructor(device as QTCaptureDevice)
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare function alloc lib CocoaLib selector "alloc" (class_id as Ptr) as Ptr
 		    declare function initWithDevice lib CocoaLib selector "initWithDevice:" (obj_id as Ptr, device as Ptr) as Ptr
 		    
@@ -20,7 +20,9 @@ Inherits NSObject
 	#tag ViewBehavior
 		#tag ViewProperty
 			Name="Description"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="String"
 			EditorType="MultiLineEditor"
 		#tag EndViewProperty
@@ -30,6 +32,7 @@ Inherits NSObject
 			Group="ID"
 			InitialValue="-2147483648"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Left"
@@ -37,18 +40,23 @@ Inherits NSObject
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Name"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Super"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Top"
@@ -56,6 +64,7 @@ Inherits NSObject
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 	#tag EndViewBehavior
 End Class

--- a/macoslib/QTKit/QTCaptureSession.xojo_code
+++ b/macoslib/QTKit/QTCaptureSession.xojo_code
@@ -3,7 +3,7 @@ Class QTCaptureSession
 Inherits NSObject
 	#tag Method, Flags = &h0
 		Sub AddInput(qtInput as QTCaptureDeviceInput)
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare function addInput lib QTKit.framework selector "addInput:error:" (obj_id as Ptr, input_ as Ptr, ByRef errorPtr as Ptr) as Boolean
 		    
 		    dim errorPtr as Ptr
@@ -19,7 +19,7 @@ Inherits NSObject
 
 	#tag Method, Flags = &h1000
 		Sub Constructor()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare function alloc lib CocoaLib selector "alloc" (class_id as Ptr) as Ptr
 		    declare function init lib CocoaLib selector "init" (obj_id as Ptr) as Ptr
 		    
@@ -33,7 +33,7 @@ Inherits NSObject
 
 	#tag Method, Flags = &h0
 		Sub StartRunning()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub startRunning lib QTKit.framework selector "startRunning" (obj_id as Ptr)
 		    
 		    startRunning(self)
@@ -43,7 +43,7 @@ Inherits NSObject
 
 	#tag Method, Flags = &h0
 		Sub StopRunning()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub stopRunning lib QTKit.framework selector "stopRunning" (obj_id as Ptr)
 		    
 		    stopRunning(self)
@@ -55,7 +55,7 @@ Inherits NSObject
 	#tag ComputedProperty, Flags = &h0
 		#tag Getter
 			Get
-			  #if targetMacOS and targetX86
+			  #If targetMacOS and targetX86
 			    declare function isRunning lib QTKit.framework selector "isRunning" (obj_id as Ptr) as Boolean
 			    
 			    return isRunning(self)
@@ -69,7 +69,9 @@ Inherits NSObject
 	#tag ViewBehavior
 		#tag ViewProperty
 			Name="Description"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="String"
 			EditorType="MultiLineEditor"
 		#tag EndViewProperty
@@ -79,11 +81,15 @@ Inherits NSObject
 			Group="ID"
 			InitialValue="-2147483648"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="IsRunning"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="Boolean"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Left"
@@ -91,18 +97,23 @@ Inherits NSObject
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Name"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Super"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Top"
@@ -110,6 +121,7 @@ Inherits NSObject
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 	#tag EndViewBehavior
 End Class

--- a/macoslib/QTKit/QTCaptureView.xojo_code
+++ b/macoslib/QTKit/QTCaptureView.xojo_code
@@ -39,7 +39,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Function AvailableVideoPreviewConnections() As QTCaptureConnection()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare function availableVideoPreviewConnections lib CocoaLib selector "availableVideoPreviewConnections" (obj_id as Ptr) as Ptr
 		    
 		    dim theArray as new CFArray(availableVideoPreviewConnections(self), not CFType.hasOwnership)
@@ -55,7 +55,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Function CaptureSession() As QTCaptureSession
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare function captureSession lib CocoaLib selector "captureSession" (obj_id as Ptr) as Ptr
 		    
 		    dim p as Ptr = captureSession(self)
@@ -70,7 +70,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub CaptureSession(assigns value as QTCaptureSession)
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub setCaptureSession lib QTKit.framework selector "setCaptureSession:" (obj_id as Ptr, value as Ptr)
 		    
 		    setCaptureSession(self, value)
@@ -86,7 +86,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Function PreviewBounds() As Cocoa.NSRect
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare function previewBounds lib CocoaLib selector "previewBounds" (obj_id as Ptr) as Cocoa.NSRect
 		    
 		    return previewBounds(self)

--- a/macoslib/QTKit/QTMovie.xojo_code
+++ b/macoslib/QTKit/QTMovie.xojo_code
@@ -3,7 +3,7 @@ Class QTMovie
 Inherits NSObject
 	#tag Method, Flags = &h0
 		Function CurrentTime() As QTTime
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare function currentTime lib QTKit.framework selector "currentTime" (obj_id as Ptr) as QTTime
 		    
 		    return currentTime(self)
@@ -13,7 +13,7 @@ Inherits NSObject
 
 	#tag Method, Flags = &h0
 		Sub CurrentTime(assigns value as QTTime)
-		  #if targetMacOS and targetX86
+		  #if targetCocoa
 		    declare sub setCurrentTime lib CocoaLib selector "setCurrentTime:" (obj_id as Ptr, time as QTTime)
 		    
 		    setCurrentTime(self, value)
@@ -27,7 +27,7 @@ Inherits NSObject
 
 	#tag Method, Flags = &h0
 		Function Duration() As QTTime
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare function duration lib QTKit.framework selector "duration" (obj_id as Ptr) as QTTime
 		    
 		    return duration(self)
@@ -101,7 +101,7 @@ Inherits NSObject
 
 	#tag Method, Flags = &h0
 		Function QTAttribute(key as String) As Ptr
-		  #if targetMacOS and targetX86
+		  #if targetCocoa
 		    declare function attributeForKey lib CocoaLib selector "attributeForKey:" (obj_id as Ptr, key as CFStringRef) as Ptr
 		    
 		    return attributeForKey(self, key)
@@ -115,7 +115,7 @@ Inherits NSObject
 
 	#tag Method, Flags = &h0
 		Sub QTAttribute(key as String, assigns value as Ptr)
-		  #if targetMacOS and targetX86
+		  #if targetCocoa
 		    declare sub setAttribute lib CocoaLib selector "setAttribute:" (obj_id as Ptr, value as Ptr, key as CFStringRef)
 		    
 		    setAttribute(self, value, key)
@@ -247,7 +247,9 @@ Inherits NSObject
 	#tag ViewBehavior
 		#tag ViewProperty
 			Name="Description"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="String"
 			EditorType="MultiLineEditor"
 		#tag EndViewProperty
@@ -257,6 +259,7 @@ Inherits NSObject
 			Group="ID"
 			InitialValue="-2147483648"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Left"
@@ -264,23 +267,31 @@ Inherits NSObject
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Muted"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="Boolean"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Name"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Super"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Top"
@@ -288,6 +299,7 @@ Inherits NSObject
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 	#tag EndViewBehavior
 End Class

--- a/macoslib/QTKit/QTMovieView.xojo_code
+++ b/macoslib/QTKit/QTMovieView.xojo_code
@@ -42,7 +42,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub Add()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub add lib QTKit.framework selector "add:" (obj_id as Ptr, sender as Ptr)
 		    
 		    add(self, nil)
@@ -52,7 +52,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub AddScaled()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub addScaled lib QTKit.framework selector "addScaled:" (obj_id as Ptr, sender as Ptr)
 		    
 		    addScaled(self, nil)
@@ -62,7 +62,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub Copy()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub copy lib QTKit.framework selector "copy:" (obj_id as Ptr, sender as Ptr)
 		    
 		    copy(self, nil)
@@ -72,7 +72,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub Cut()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub cut lib QTKit.framework selector "cut:" (obj_id as Ptr, sender as Ptr)
 		    
 		    cut(self, nil)
@@ -82,7 +82,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub Delete()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub delete lib QTKit.framework selector "delete:" (obj_id as Ptr, sender as Ptr)
 		    
 		    delete(self, nil)
@@ -119,7 +119,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub GotoBeginning()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub gotoBeginning lib QTKit.framework selector "gotoBeginning:" (obj_id as Ptr, sender as Ptr)
 		    
 		    gotoBeginning(self, nil)
@@ -129,7 +129,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub GotoEnd()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub gotoEnd lib QTKit.framework selector "gotoEnd:" (obj_id as Ptr, sender as Ptr)
 		    
 		    gotoEnd(self, nil)
@@ -139,7 +139,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub GotoNextSelectionPoint()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub gotoNextSelectionPoint lib QTKit.framework selector "gotoNextSelectionPoint:" (obj_id as Ptr, sender as Ptr)
 		    
 		    gotoNextSelectionPoint(self, nil)
@@ -149,7 +149,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub GotoPosterFrame()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub gotoPosterFrame lib QTKit.framework selector "gotoPosterFrame:" (obj_id as Ptr, sender as Ptr)
 		    
 		    gotoPosterFrame(self, nil)
@@ -159,7 +159,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub GotoPreviousSelectionPoint()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub gotoPreviousSelectionPoint lib QTKit.framework selector "gotoPreviousSelectionPoint:" (obj_id as Ptr, sender as Ptr)
 		    
 		    gotoPreviousSelectionPoint(self, nil)
@@ -227,7 +227,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub Paste()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub paste lib QTKit.framework selector "paste:" (obj_id as Ptr, sender as Ptr)
 		    
 		    paste(self, nil)
@@ -237,7 +237,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub Pause()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub pause lib QTKit.framework selector "pause:" (obj_id as Ptr, sender as Ptr)
 		    
 		    pause(self, nil)
@@ -247,7 +247,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub Play()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub play lib QTKit.framework selector "play:" (obj_id as Ptr, sender as Ptr)
 		    
 		    play(self, nil)
@@ -257,7 +257,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub Replace()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub replace lib QTKit.framework selector "replace:" (obj_id as Ptr, sender as Ptr)
 		    
 		    replace(self, nil)
@@ -267,7 +267,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub SelectAll()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub selectAll lib QTKit.framework selector "selectAll:" (obj_id as Ptr, sender as Ptr)
 		    
 		    selectAll(self, nil)
@@ -277,7 +277,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub SelectNone()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub selectNone lib QTKit.framework selector "selectNone:" (obj_id as Ptr, sender as Ptr)
 		    
 		    selectNone(self, nil)
@@ -287,7 +287,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub StepBackward()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub stepBackward lib QTKit.framework selector "stepBackward:" (obj_id as Ptr, sender as Ptr)
 		    
 		    stepBackward(self, nil)
@@ -297,7 +297,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub StepForward()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub stepForward lib QTKit.framework selector "stepForward:" (obj_id as Ptr, sender as Ptr)
 		    
 		    stepForward(self, nil)
@@ -307,7 +307,7 @@ Inherits Canvas
 
 	#tag Method, Flags = &h0
 		Sub Trim()
-		  #if targetMacOS and targetX86
+		  #If targetMacOS and targetX86
 		    declare sub trim lib QTKit.framework selector "trim:" (obj_id as Ptr, sender as Ptr)
 		    
 		    trim(self, nil)
@@ -324,7 +324,7 @@ Inherits Canvas
 	#tag ComputedProperty, Flags = &h0
 		#tag Getter
 			Get
-			  #if targetMacOS and targetX86
+			  #If targetMacOS and targetX86
 			    declare function controllerBarHeight lib QTKit.framework selector "controllerBarHeight" (obj_id as Ptr) as Double
 			    
 			    return CType(controllerBarHeight(self), Double)


### PR DESCRIPTION
My previous work to prevent QTKit.framework from being included on ARM builds was incomplete. This change verifies that all references to QTKit.framework are wrapped in "#if targetMacOS and targetX86" so it is only used on Intel builds.